### PR TITLE
Jv add make tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,16 @@
+.DEFAULT_GOAL = all
+
+ifeq ($(BERSERKER_TAG),)
+BERSERKER_TAG=$(shell git describe --tags --abbrev=10 --dirty)
+endif
+
+
+.PHONY: all
 all:
 	docker build -t builder -f Dockerfile.build .
 	docker build -t berserker .
+
+
+.PHONY: tag
+tag:
+	@echo "$(BERSERKER_TAG)"


### PR DESCRIPTION
Adds the ability to run `make tag`. This will be useful in tagging images, which in turn will useful in using and pulling specific versions of berserker. The next step after this PR is to push the images to quay.io/stackrox-io in CI. This is done here https://github.com/stackrox/berserker/pull/4. This will make it easier to use berserker in kube-burner for long running collector.

## Testing

```
make tag
1.0-2-g2ab55995a6
```