### PR TITLE
Jv push image in ci

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
           echo "TAG=$TAG" >> $GITHUB_ENV 
 
       - name: Retag and push stackrox-io
-        uses: stackrox/actions/images/retag-and-push@jv-ROX-19084-github-action-to-retag-and-push-images
+        uses: stackrox/actions/images/retag-and-push@v1
         with:
           src-image: berserker
           dst-image: quay.io/rhacs-eng/qa:berserker-${{ env.TAG }}


### PR DESCRIPTION
Push the built berserker images to quay.io/stackrox-io. I have not actually added the secrets to make this work. This PR is built on top of another PR that add the make target, tag. See https://github.com/stackrox/berserker/pull/3

## Checklist

- [x] Able to pull image pushed by CI

## Testing

https://github.com/stackrox/berserker/actions/runs/6017990482/job/16325361926?pr=4

has 

```
Run stackrox/actions/images/retag-and-push@v1
Run dst_image=quay.io/rhacs-eng/qa:berserker-1.0-35-g69fd45f927
  dst_image=quay.io/rhacs-eng/qa:berserker-1.0-35-g69fd45f927
  registry="${dst_image%%/*}"
  echo "registry=$registry" >> $GITHUB_OUTPUT
  shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
  env:
    TAG: 1.0-35-g69fd45f927
```

The following command was run locally
```
docker pull quay.io/rhacs-eng/qa:berserker-1.0-35-g69fd45f927
berserker-1.0-35-g69fd45f927: Pulling from rhacs-eng/qa
f68bc6b02769: Pull complete 
ece7ecc37cd2: Pull complete 
3b66ae725245: Pull complete 
0523fe6378d2: Pull complete 
1e000ca05414: Pull complete 
Digest: sha256:ebd1f279b691e228d47f16e586f61f3372920a389cb5521ea2c9bd497726572d
Status: Downloaded newer image for quay.io/rhacs-eng/qa:berserker-1.0-35-g69fd45f927
quay.io/rhacs-eng/qa:berserker-1.0-35-g69fd45f927
```