### PR TITLE
Jv listen on unspecified address

### DIFF
--- a/src/worker/endpoints.rs
+++ b/src/worker/endpoints.rs
@@ -71,7 +71,7 @@ impl Display for EndpointWorker {
 }
 
 fn listen(port: usize, sleep: u64) -> std::io::Result<()> {
-    let addr = format!("127.0.0.1:{port}");
+    let addr = format!("0.0.0.0:{port}");
     let listener = TcpListener::bind(addr)?;
 
     let _res = listener.incoming();


### PR DESCRIPTION
When creating listening endpoints load berserker currently listens to the local IP address 127.0.0.1. The problem with this is that collector filters out all listening endpoints listening on the local IP address.

ProcfsScraper.cpp has the following
```
// ResolveSocketInodes takes a netns -> (inode -> connection info) mapping and a
// container id -> (netns -> socket) mapping, and synthesizes this to a list of (container id, connection info)
// tuples.
void ResolveSocketInodes(const SocketsByContainer& sockets_by_container, const ConnsByNS& conns_by_ns,
                         std::shared_ptr<ProcessStore> process_store,
                         std::vector<Connection>* connections, std::vector<ContainerEndpoint>* listen_endpoints) {
  for (const auto& container_sockets : sockets_by_container) {
    const auto& container_id = container_sockets.first;
    for (const auto& netns_sockets : container_sockets.second) {
      const auto* ns_network_data = Lookup(conns_by_ns, netns_sockets.first);
      if (!ns_network_data) continue;
      for (const auto& socket : netns_sockets.second) {
        if (const auto* conn = Lookup(ns_network_data->connections, socket.inode())) {
          Connection connection(container_id, conn->local, conn->remote, conn->l4proto, conn->is_server);
          if (!IsRelevantConnection(connection)) continue;
          connections->push_back(std::move(connection));
        } else if (listen_endpoints) {
          if (const auto* ep = Lookup(ns_network_data->listen_endpoints, socket.inode())) {
            if (!IsRelevantEndpoint(ep->endpoint)) continue;

            std::shared_ptr<IProcess> process;

            if (process_store) {
              process = process_store->Fetch(socket.pid());
            }

            listen_endpoints->emplace_back(container_id, ep->endpoint, ep->l4proto, process);
          }
        }
      }
    }
  }
}
```

The key line here being
```
if (!IsRelevantEndpoint(ep->endpoint)) continue;
```

`IsRelevantEndpoint` in turn is the following
```
// Checks if the given endpoints is relevant (i.e., it is not only listening on local loopback).
inline bool IsRelevantEndpoint(const Endpoint& ep) {
  return !ep.address().IsLocal();
}
```

The shows that endpoints listening on 127.0.0.1 are not reported by collector.

## Testing

### Collector integration tests

Run a berserker container. Run one of the collector integration tests. 

make -C integration-tests TestSocat

Check the grpc-server logs. With the a berserker container listening on 127.0.0.1, there are no listening endpoints associated with berserker. With a berserker container listening on 0.0.0.0, there are listening endpoints associated with berseker.

### Long running collector

Testing was done by deploying a long running cluster that uses berserker to create listening endpoints load. The PR used to do that is here https://github.com/stackrox/stackrox/pull/7929.

To use that PR go to https://github.com/stackrox/test-gh-actions/actions/workflows/create-clusters.yml

Click on "Run workflow". 
Change branch to jv-ROX-19857-long-running-collector-should-have-listening-endpoints-load

Select "Create a long-running cluster on RC1" and "Create a GKE demo cluster"
Click run workflow.

The names of created clusters are "real-load-4-1-1" and "fake-load-4-1-1".
Download the artifacts for the clusters and use their kubeconfigs.

Connect to the central-db in the cluster running the fake workload. Check the number of listening endpoints.

With the image where berserker listens on 127.0.0.1 (quay.io/rhacs-eng/qa:berserker-1.0-26-g56b1cf4e5d)
```
central_active=# select count(*) from listening_endpoints ;
-[ RECORD 1 ]
count | 188
```

With the image where berserker listens on 0.0.0.0 (quay.io/rhacs-eng/qa:berserker-1.0-38-ge3b292786)
```
central_active=# select count(*) from listening_endpoints ;
-[ RECORD 1 ]
count | 20987
```




