### PR TITLE
Fix some formatting errors on let else statements

### DIFF
--- a/src/worker/processes.rs
+++ b/src/worker/processes.rs
@@ -30,7 +30,10 @@ impl ProcessesWorker {
             arrival_rate: _,
             departure_rate: _,
             random_process,
-        } = self.workload.workload else { unreachable!() };
+        } = self.workload.workload
+        else {
+            unreachable!()
+        };
         let BaseConfig { cpu, process } = self.config;
 
         if random_process {
@@ -71,7 +74,10 @@ impl Worker for ProcessesWorker {
             arrival_rate,
             departure_rate,
             random_process: _,
-        } = self.workload.workload else {unreachable!()};
+        } = self.workload.workload
+        else {
+            unreachable!()
+        };
 
         loop {
             let lifetime: f64 = thread_rng().sample(Exp::new(departure_rate).unwrap());

--- a/src/worker/syscalls.rs
+++ b/src/worker/syscalls.rs
@@ -39,7 +39,9 @@ impl Worker for SyscallsWorker {
     fn run_payload(&self) -> Result<(), super::WorkerError> {
         info!("{self}");
 
-        let Workload::Syscalls { arrival_rate } = self.workload.workload else {unreachable!()};
+        let Workload::Syscalls { arrival_rate } = self.workload.workload else {
+            unreachable!()
+        };
 
         loop {
             let worker = *self;


### PR DESCRIPTION
Formatting for this kind of statements was added by https://github.com/rust-lang/rustfmt/pull/5690. We had statements prior to this being available, so we should now fix those.