### PR TITLE
Berserker network deployment

### DIFF
--- a/scripts/network/Dockerfile
+++ b/scripts/network/Dockerfile
@@ -1,0 +1,9 @@
+FROM berserker:latest
+
+RUN dnf install -y which iproute bpftool procps iptables
+
+COPY prepare-tap.sh /scripts/
+COPY init.sh /scripts/
+COPY workloads /etc/berserker/
+
+ENTRYPOINT ["/scripts/init.sh"]

--- a/scripts/network/init.sh
+++ b/scripts/network/init.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -eo pipefail
+
+IP_BASE="223.42.0.1/16"
+
+/scripts/prepare-tap.sh -a "$IP_BASE" -o
+
+berserker /etc/berserker/network-server.toml &
+
+SERVER_PID=$!
+
+berserker /etc/berserker/network-client.toml &
+
+CLIENT_PID=$!
+
+cleanup() {
+    echo "Killing client ($CLIENT_PID) and server ($SERVER_PID)"
+
+    kill -9 $CLIENT_PID
+    kill -9 $SERVER_PID
+
+    exit
+}
+
+trap cleanup SIGINT SIGKILL SIGABRT
+
+wait $SERVER_PID

--- a/scripts/network/init.sh
+++ b/scripts/network/init.sh
@@ -2,7 +2,7 @@
 
 set -eo pipefail
 
-IP_BASE="223.42.0.1/16"
+IP_BASE="${IP_BASE:-223.42.0.1/16}"
 
 /scripts/prepare-tap.sh -a "$IP_BASE" -o
 
@@ -17,12 +17,12 @@ CLIENT_PID=$!
 cleanup() {
     echo "Killing client ($CLIENT_PID) and server ($SERVER_PID)"
 
-    kill -9 $CLIENT_PID
-    kill -9 $SERVER_PID
+    kill -9 "$CLIENT_PID"
+    kill -9 "$SERVER_PID"
 
     exit
 }
 
-trap cleanup SIGINT SIGKILL SIGABRT
+trap cleanup SIGINT SIGABRT
 
-wait $SERVER_PID
+wait -n "$SERVER_PID" "$CLIENT_PID"

--- a/scripts/network/prepare-tap.sh
+++ b/scripts/network/prepare-tap.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 set -eou pipefail
-set -x
 
 # This script helps to prepare an environment for developing berserker network
 # workload. It has the following preparatory steps:

--- a/scripts/network/workloads/network-client.toml
+++ b/scripts/network/workloads/network-client.toml
@@ -1,0 +1,12 @@
+restart_interval = 10
+workers = 1
+per_core = false
+
+[workload]
+type = "network"
+server = false
+address = [223, 42, 0, 1]
+target_port = 1337
+arrival_rate = 0.1
+departure_rate = 0.1
+nconnections = 100

--- a/scripts/network/workloads/network-server.toml
+++ b/scripts/network/workloads/network-server.toml
@@ -7,6 +7,4 @@ type = "network"
 server = true
 address = [223, 42, 0, 1]
 target_port = 1337
-arrival_rate = 0.1
-departure_rate = 0.1
 nconnections = 100

--- a/scripts/network/workloads/network-server.toml
+++ b/scripts/network/workloads/network-server.toml
@@ -1,0 +1,12 @@
+restart_interval = 10
+workers = 1
+per_core = false
+
+[workload]
+type = "network"
+server = true
+address = [223, 42, 0, 1]
+target_port = 1337
+arrival_rate = 0.1
+departure_rate = 0.1
+nconnections = 100


### PR DESCRIPTION
This PR provides the necessary scripts, dockerfiles, and deployment definition to run a network workload as a deployment in a cluster.

In particular the container will:
- set up the tun interface
- start the berserker server
- start the berserker client

Workload configuration is also configurable via the environment, if required.