### PR TITLE
Fix network worker smoke test

### DIFF
--- a/tests/workers/network/workload.client.toml
+++ b/tests/workers/network/workload.client.toml
@@ -5,8 +5,8 @@ workers = 1
 [workload]
 type = "network"
 server = false
-address = [192, 168, 0, 1]
+address = [10, 0, 0, 1]
 target_port = 8081
-arrival_rate = 1000
+arrival_rate = 100
 departure_rate = 1
 nconnections = 10

--- a/tests/workers/network/workload.server.toml
+++ b/tests/workers/network/workload.server.toml
@@ -5,7 +5,7 @@ workers = 1
 [workload]
 type = "network"
 server = true
-address = [192, 168, 0, 1]
+address = [10, 0, 0, 1]
 target_port = 8081
 arrival_rate = 0.1
 departure_rate = 0.1


### PR DESCRIPTION
Don't bother with stopping every process one by one, correct endpoints gathering from logs and test configuration.