### PR TITLE
BPF worker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,6 +23,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "assert_matches"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
 name = "async-trait"
 version = "0.1.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -30,7 +42,7 @@ checksum = "a507401cad91ec6a857ed5513a2073c82a9b9048762b885bb98655b306964681"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -60,6 +72,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "aya"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d18bc4e506fbb85ab7392ed993a7db4d1a452c71b75a246af4a80ab8c9d2dd50"
+dependencies = [
+ "assert_matches",
+ "aya-obj",
+ "bitflags 2.6.0",
+ "bytes",
+ "libc",
+ "log",
+ "object",
+ "once_cell",
+ "thiserror",
+]
+
+[[package]]
+name = "aya-obj"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51b96c5a8ed8705b40d655273bc4212cbbf38d4e3be2788f36306f154523ec7"
+dependencies = [
+ "bytes",
+ "core-error",
+ "hashbrown 0.15.2",
+ "log",
+ "object",
+ "thiserror",
+]
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -69,12 +112,15 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 name = "berserker"
 version = "0.1.0"
 dependencies = [
+ "aya",
+ "aya-obj",
  "config",
  "core_affinity",
  "env_logger",
  "fork",
  "futures",
  "itertools",
+ "libc",
  "log",
  "nix",
  "rand",
@@ -92,6 +138,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -105,6 +157,12 @@ name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "bytes"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "cfg-if"
@@ -132,6 +190,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-error"
+version = "0.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efcdb2972eb64230b4c50646d8498ff73f5128d196a90c7236eec4cbe8619b8f"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "core_affinity"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -149,6 +216,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -173,7 +249,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3939552907426de152b3c2c6f51ed53f98f448babd26f28694c95f5906194595"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "defmt-macros",
 ]
 
@@ -187,7 +263,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -256,6 +332,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "foldhash"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
+
+[[package]]
 name = "fork"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -320,7 +408,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -393,6 +481,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
+
+[[package]]
 name = "heapless"
 version = "0.7.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -425,6 +524,16 @@ name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "indexmap"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.15.2",
+]
 
 [[package]]
 name = "itertools"
@@ -460,9 +569,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libm"
@@ -525,7 +634,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "libc",
  "memoffset",
@@ -563,10 +672,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "once_cell"
-version = "1.19.0"
+name = "object"
+version = "0.36.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
+dependencies = [
+ "crc32fast",
+ "hashbrown 0.15.2",
+ "indexmap",
+ "memchr",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "ordered-multimap"
@@ -575,7 +696,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccd746e37177e1711c20dd619a1620f34f5c8b569c53590a72dedd5344d8924a"
 dependencies = [
  "dlv-list",
- "hashbrown",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -615,7 +736,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -673,9 +794,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.79"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
+checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
 ]
@@ -765,7 +886,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88073939a61e5b7680558e6be56b419e208420c2adb92be54921fa6b72283f1a"
 dependencies = [
  "base64",
- "bitflags",
+ "bitflags 1.3.2",
  "serde",
 ]
 
@@ -823,7 +944,7 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -845,7 +966,7 @@ checksum = "0b2e6b945e9d3df726b65d6ee24060aff8e3533d431f677a9695db04eff9dfdb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -884,7 +1005,7 @@ name = "smoltcp"
 version = "0.10.0"
 source = "git+https://github.com/erthalion/smoltcp.git?branch=feature/any-ip-for-arp#2fda9698ca70e5730a774224d6610014b3474f57"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "byteorder",
  "cfg-if",
  "defmt",
@@ -922,9 +1043,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.55"
+version = "2.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "002a1b3dbf967edfafc32655d0f377ab0bb7b994aa1d32c8cc7e9b8bf3ebb8f0"
+checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -979,7 +1100,7 @@ checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.90",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,7 @@ env_logger = "0.9.0"
 config = "0.13.3"
 syscalls = "0.6.13"
 serde = { version = "1.0.171", features = ["derive"] }
+libc = "0.2.169"
 smoltcp = {git = "https://github.com/erthalion/smoltcp.git", branch="feature/any-ip-for-arp"}
+aya = "0.13.1"
+aya-obj = "0.2.1"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM builder:latest as builder
 
-FROM registry.fedoraproject.org/fedora:38
+FROM registry.fedoraproject.org/fedora:41
 
 RUN mkdir /etc/berserker
 

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:38
+FROM registry.fedoraproject.org/fedora:41
 
 RUN dnf install -y rust cargo nasm
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ workloads:
   connections. To reduce amount of resources needed for such simulation, a tun
   device is used to craft an external client connection in the userspace.
 
+* BPF based workload, which creates a specified number of simple BPF programs,
+  attached to a specified tracepoint. This allows to simulate program
+  contention on the same attachment point.
+
 Every workload is executed via set of worker processes, that are distributed
 among available system CPU cores to fully utilize system resources.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,6 +103,27 @@ pub enum Workload {
         #[serde(default = "default_network_send_interval")]
         send_interval: u128,
     },
+
+    /// How to load bpf progs.
+    Bpf {
+        /// Which tracepoint BPF programs will be attached to. Could be taken
+        /// from the tracefs, e.g.
+        /// /sys/kernel/debug/tracing/events/sched/sched_process_exit/id
+        #[serde(default = "default_bpf_tracepoint")]
+        tracepoint: u64,
+
+        /// Number of BPF programs to launch
+        #[serde(default = "default_bpf_nprogs")]
+        nprogs: u64,
+    },
+}
+
+fn default_bpf_tracepoint() -> u64 {
+    306
+}
+
+fn default_bpf_nprogs() -> u64 {
+    100
 }
 
 fn default_network_send_interval() -> u128 {

--- a/src/worker/bpf.rs
+++ b/src/worker/bpf.rs
@@ -1,0 +1,141 @@
+use std::{
+    cmp,
+    ffi::{c_char, CString},
+    fmt::Display,
+    mem, slice, thread,
+};
+
+use core_affinity::CoreId;
+use libc::{SYS_bpf, SYS_perf_event_open};
+use log::info;
+
+use aya_obj::copy_instructions;
+use aya_obj::generated::{
+    bpf_attach_type, bpf_attr, bpf_cmd, bpf_prog_type, perf_event_attr,
+    perf_event_sample_format, perf_type_id,
+};
+
+use crate::{BaseConfig, Worker, WorkerError, Workload, WorkloadConfig};
+
+#[derive(Debug, Clone, Copy)]
+pub struct BpfWorker {
+    config: BaseConfig,
+    workload: WorkloadConfig,
+}
+
+impl BpfWorker {
+    pub fn new(workload: WorkloadConfig, cpu: CoreId, process: usize) -> Self {
+        BpfWorker {
+            config: BaseConfig { cpu, process },
+            workload,
+        }
+    }
+}
+
+impl Worker for BpfWorker {
+    fn run_payload(&self) -> Result<(), WorkerError> {
+        info!("{self}");
+
+        let Workload::Bpf { nprogs, tracepoint } = self.workload.workload
+        else {
+            unreachable!()
+        };
+
+        // Prepare the bpf program attributes
+        let mut attr = unsafe { mem::zeroed::<bpf_attr>() };
+        let u = unsafe { &mut attr.__bindgen_anon_3 };
+        let mut prog_fd;
+        let mut name: [c_char; 16] = [0; 16];
+
+        // A simple two instruction BPF program, inspired by aya probes.
+        let prog: &[u8] = &[
+            0xb7, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, // mov64 r0 = 0
+            0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // exit
+        ];
+
+        let gpl = b"GPL\0";
+        u.license = gpl.as_ptr() as u64;
+
+        let insns = copy_instructions(prog).unwrap();
+        u.insn_cnt = insns.len() as u32;
+        u.insns = insns.as_ptr() as u64;
+        // TODO: Extend for more target types
+        u.prog_type = bpf_prog_type::BPF_PROG_TYPE_TRACEPOINT as u32;
+
+        // Prepare the perf event attribute to find the attachment target
+        let mut perf_attr = unsafe { mem::zeroed::<perf_event_attr>() };
+        let mut perf_event_fd;
+
+        perf_attr.config = tracepoint;
+        perf_attr.size = mem::size_of::<perf_event_attr>() as u32;
+        perf_attr.type_ = perf_type_id::PERF_TYPE_TRACEPOINT as u32;
+        perf_attr.sample_type =
+            perf_event_sample_format::PERF_SAMPLE_RAW as u64;
+        perf_attr.set_inherit(0);
+
+        // Prepare the bpf link attribute
+        let mut link_attr = unsafe { mem::zeroed::<bpf_attr>() };
+        link_attr.link_create.attach_type =
+            bpf_attach_type::BPF_PERF_EVENT as u32;
+
+        for i in 0..nprogs {
+            let cstring = CString::new(format!("berserker{i}")).unwrap();
+            let name_bytes = cstring.to_bytes();
+            let len = cmp::min(name.len(), name_bytes.len());
+            name[..len].copy_from_slice(unsafe {
+                slice::from_raw_parts(name_bytes.as_ptr() as *const c_char, len)
+            });
+            attr.__bindgen_anon_3.prog_name = name;
+
+            // Load the BPF program
+            unsafe {
+                prog_fd = libc::syscall(
+                    SYS_bpf,
+                    bpf_cmd::BPF_PROG_LOAD,
+                    &attr,
+                    mem::size_of::<bpf_attr>(),
+                );
+            }
+
+            // Now prepare a tracepoint event the bpf program
+            // will be attached to
+            unsafe {
+                perf_event_fd = libc::syscall(
+                    SYS_perf_event_open,
+                    &perf_attr,
+                    0,
+                    -1,
+                    -1,
+                    0,
+                );
+            }
+
+            // And finally create a link between the program
+            // and the tracepoint
+            link_attr.link_create.__bindgen_anon_1.prog_fd = prog_fd as u32;
+            link_attr.link_create.__bindgen_anon_2.target_fd =
+                perf_event_fd as u32;
+            unsafe {
+                libc::syscall(
+                    SYS_bpf,
+                    bpf_cmd::BPF_LINK_CREATE,
+                    &link_attr,
+                    mem::size_of::<bpf_attr>(),
+                );
+            }
+        }
+
+        // We don't recreate those programs, and just let them live
+        // for the duration of the run, blocking the main loop.
+        loop {
+            thread::park();
+        }
+    }
+}
+
+impl Display for BpfWorker {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.config)
+    }
+}

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -5,10 +5,11 @@ use rand_distr::{Uniform, Zipf};
 use crate::{Distribution, Worker, Workload, WorkloadConfig};
 
 use self::{
-    endpoints::EndpointWorker, network::NetworkWorker,
+    bpf::BpfWorker, endpoints::EndpointWorker, network::NetworkWorker,
     processes::ProcessesWorker, syscalls::SyscallsWorker,
 };
 
+pub mod bpf;
 pub mod endpoints;
 pub mod network;
 pub mod processes;
@@ -56,6 +57,9 @@ pub fn new_worker(
         }
         Workload::Network { .. } => {
             Box::new(NetworkWorker::new(workload, cpu, process))
+        }
+        Workload::Bpf { .. } => {
+            Box::new(BpfWorker::new(workload, cpu, process))
         }
     }
 }

--- a/workloads/bpf.toml
+++ b/workloads/bpf.toml
@@ -1,0 +1,8 @@
+restart_interval = 10
+per_core = false
+workers = 1
+
+[workload]
+type = "bpf"
+tracepoint = 306
+nporgs = 100


### PR DESCRIPTION
BPF program worker to simulate contention on a tracepoint. The implementation benefits from aya types, but uses raw syscalls to do actual job, since we don't want to depend on any external BPF programs and generate everything on the fly. The resulting programs are simplest possible, which is enough to simulate a contention.