### PR TITLE
ROX-28740: Set IP address in berserker using an env var

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,11 +176,11 @@ where
                 .map(|x| x.trim().parse::<u8>())
                 .collect::<Result<_, _>>()
                 .map_err(D::Error::custom)?;
-        
+
             if parts.len() != 4 {
                 return Err(D::Error::custom("IP address should have 4 parts"));
             }
-        
+
             Ok((parts[0], parts[1], parts[2], parts[3]))
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,7 +171,9 @@ where
         AddressInput::Array(a) => Ok((a[0], a[1], a[2], a[3])),
         AddressInput::Str(s) => {
             let parts: Vec<u8> = s
-                .trim_matches(|c: char| c == '[' || c == ']' || c.is_whitespace())
+                .trim_matches(|c: char| {
+                    c == '[' || c == ']' || c.is_whitespace()
+                })
                 .split(',')
                 .map(|x| x.trim().parse::<u8>())
                 .collect::<Result<_, _>>()


### PR DESCRIPTION
It is possible to configure settings using a config file or environment variable. However, currently when setting the IP address using an environment variable the following error results

called Result::unwrap() on an Err value: invalid type: string "[223, 42, 0, 1]", expected a tuple of size 4
note: run with RUST_BACKTRACE=1 environment variable to display a backtrace

### Testing

This PR was tested by basing on top of another branch which can be found here https://github.com/stackrox/berserker/pull/32

The image built using a modification of that branch was incorporated into kube-burner configuration files here https://github.com/stackrox/stackrox/pull/14790

Starting from the root of the berserker repository built the image

```
make
```

Then built the image with prepare-tap.sh and pushed it

```
cd scripts/network
make build .

docker image ls | head
REPOSITORY                                                                  TAG                                                  IMAGE ID       CREATED             SIZE
<none>                                                                      <none>                                               3620165f9c14   56 seconds ago      502MB

docker tag 3620165f9c14 quay.io/jvirtane/berserker-connection-load-1.0-69-g959d27d476-dirty-7
docker push quay.io/jvirtane/berserker-connection-load-1.0-69-g959d27d476-dirty-7
```

Created an infra cluster, obtained the artifacts, and set KUBECONFIG accordingly.

Then in the stackrox/actions repository

```
cd release/start-kube-burner

KUBE_BURNER_CONFIG_DIR=/home/jvirtane/go/src/github.com/stackrox/stackrox/scripts/release-tools/kube-burner-configs
export BENCHMARK_OPERATOR_DIR=/home/jvirtane/software/benchmark-operator

./start-kube-burner.sh
```

Checked the pods in the kube-burner namespaces
```
kubectl -n cluster-density-1 get pod
NAME                                 READY   STATUS    RESTARTS   AGE
connection-load-1-56c5cbfc94-cdfvs   1/1     Running   0          3m46s
connection-load-1-56c5cbfc94-vs8mg   1/1     Running   0          3m47s
connection-load-2-f46474bfd-6sld7    1/1     Running   0          3m45s
connection-load-2-f46474bfd-xkn9g    1/1     Running   0          3m46s
connection-load-3-7d8679899d-b9bjx   1/1     Running   0          3m42s
connection-load-3-7d8679899d-cb6hp   1/1     Running   0          3m43s
connection-load-4-5949b6d85d-2m5vx   1/1     Running   0          3m45s
connection-load-4-5949b6d85d-vvtt6   1/1     Running   0          3m45s
connection-load-5-85d4dc5d6-wgvpg    1/1     Running   0          3m44s
connection-load-5-85d4dc5d6-x4947    1/1     Running   0          3m45s
```

Checked the UI and confirmed that the pods had connections to external entities.

Removed the env var section so that the config file would be used

```
        env:
          - name: IP_BASE
            value: "{{ $ip }}"
          - name: BERSERKER__WORKLOAD__ADDRESS
            value: "{{ $berserker_address }}"
```

Deleted the kube-burner namespaces and started it again. Checked the pods and network graph again.