### PR TITLE
Use std::net::Ipv4Addr as the type for network addresses

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 use core_affinity::CoreId;
 use serde::Deserialize;
-use std::fmt::Display;
+use std::{fmt::Display, net::Ipv4Addr};
 use syscalls::Sysno;
 
 pub mod worker;
@@ -101,7 +101,7 @@ pub enum Workload {
 
         /// Which ip address to use for the server to listen on,
         /// or for the client to connect to
-        address: (u8, u8, u8, u8),
+        address: Ipv4Addr,
 
         /// Port for the server to listen on, or for the client
         /// to connect to.

--- a/src/worker/network.rs
+++ b/src/worker/network.rs
@@ -388,12 +388,10 @@ impl Worker for NetworkWorker {
             unreachable!()
         };
 
-        let ip_addr = Ipv4Address([address.0, address.1, address.2, address.3]);
-
         if server {
-            let _ = self.start_server(ip_addr, target_port);
+            let _ = self.start_server(address.into(), target_port);
         } else {
-            let _ = self.start_client(ip_addr, target_port);
+            let _ = self.start_client(address.into(), target_port);
         }
 
         Ok(())

--- a/tests/workers/network/workload.client.toml
+++ b/tests/workers/network/workload.client.toml
@@ -5,7 +5,7 @@ workers = 1
 [workload]
 type = "network"
 server = false
-address = [10, 0, 0, 1]
+address = "10.0.0.1"
 target_port = 8081
 arrival_rate = 100
 departure_rate = 1

--- a/tests/workers/network/workload.server.toml
+++ b/tests/workers/network/workload.server.toml
@@ -5,7 +5,7 @@ workers = 1
 [workload]
 type = "network"
 server = true
-address = [10, 0, 0, 1]
+address = "10.0.0.1"
 target_port = 8081
 arrival_rate = 0.1
 departure_rate = 0.1

--- a/workloads/network.toml
+++ b/workloads/network.toml
@@ -3,7 +3,7 @@ restart_interval = 10
 [workload]
 type = "network"
 server = false
-address = [192, 168, 0, 1]
+address = "192.168.0.1"
 target_port = 8080
 arrival_rate = 0.1
 departure_rate = 0.1


### PR DESCRIPTION
By using this type, we should be able to deserialize regular looking ipv4 addresses rather than a tuple. From there, we can directly change them to a smoltcp::wire::Ipv4Addr by calling .into() at the right spot.