### PR TITLE
ROX-28861: Make Berserker connection load more configurable

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,8 +118,8 @@ pub enum Workload {
 
         // How many connections to make to the same server address and port with
         // different client ports
-        #[serde(default = "default_ports_per_addr")]
-        ports_per_addr: u16,
+        #[serde(default = "default_conns_per_addr")]
+        conns_per_addr: u16,
 
         /// How often send data via new connections, in milliseconds.
         /// The interval is applied for all connections, e.g. an interval
@@ -153,7 +153,7 @@ fn default_bpf_nprogs() -> u64 {
     100
 }
 
-fn default_ports_per_addr() -> u16 {
+fn default_conns_per_addr() -> u16 {
     100
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,6 +116,11 @@ pub enum Workload {
         /// Starting number of connections
         nconnections: u32,
 
+        // How many connections to make to the same server address and port with
+        // different client ports
+        #[serde(default = "default_ports_per_addr")]
+        ports_per_addr: u16,
+
         /// How often send data via new connections, in milliseconds.
         /// The interval is applied for all connections, e.g. an interval
         /// of 100 ms for 100 connections means that every 100 ms one out
@@ -145,6 +150,10 @@ fn default_bpf_tracepoint() -> u64 {
 }
 
 fn default_bpf_nprogs() -> u64 {
+    100
+}
+
+fn default_ports_per_addr() -> u16 {
     100
 }
 

--- a/src/worker/network.rs
+++ b/src/worker/network.rs
@@ -384,7 +384,7 @@ impl Worker for NetworkWorker {
             arrival_rate: _,
             departure_rate: _,
             nconnections: _,
-            ports_per_addr,
+            ports_per_addr: _,
             send_interval: _,
         } = self.workload.workload
         else {

--- a/src/worker/network.rs
+++ b/src/worker/network.rs
@@ -143,7 +143,8 @@ impl NetworkWorker {
             .enumerate()
         {
             let index = i as u64;
-            let (local_addr, local_port) = get_local_addr_port(addr, conns_per_addr, index);
+            let (local_addr, local_port) =
+                get_local_addr_port(addr, conns_per_addr, index);
             info!("connecting from {}:{}", local_addr, local_port);
             socket
                 .connect(cx, (addr, target_port), (local_addr, local_port))
@@ -185,7 +186,8 @@ impl NetworkWorker {
                 let mut socket = tcp::Socket::new(tcp_rx_buffer, tcp_tx_buffer);
 
                 let index = total_conns as u64;
-                let (local_addr, local_port) = get_local_addr_port(addr, conns_per_addr, index);
+                let (local_addr, local_port) =
+                    get_local_addr_port(addr, conns_per_addr, index);
 
                 socket
                     .connect(
@@ -345,7 +347,6 @@ impl NetworkWorker {
 
         (iface, device, fd)
     }
-
 }
 
 /// Map socket index to a local port and address. The address octets are
@@ -427,39 +428,41 @@ mod tests {
                 10,
                 15,
                 IpAddress::v4(192, 168, 1, 101),
-                49157
+                49157,
             ),
             (
                 Ipv4Address::new(192, 168, 1, 255),
                 9,
                 15,
                 IpAddress::v4(192, 168, 2, 0),
-                49158
+                49158,
             ),
             (
                 Ipv4Address::new(192, 255, 255, 255),
                 12,
                 15,
                 IpAddress::v4(193, 0, 0, 0),
-                49155
+                49155,
             ),
             (
                 Ipv4Address::new(192, 168, 1, 100),
                 1,
                 512,
                 IpAddress::v4(192, 168, 3, 100),
-                49152
+                49152,
             ),
             (
                 Ipv4Address::new(192, 168, 1, 100),
                 1,
                 65636,
                 IpAddress::v4(192, 169, 1, 200),
-                49152
+                49152,
             ),
         ];
 
-        for (addr, conns_per_addr, index, expected_ip, expected_port) in test_cases {
+        for (addr, conns_per_addr, index, expected_ip, expected_port) in
+            test_cases
+        {
             let (ip, port) = get_local_addr_port(addr, conns_per_addr, index);
             assert_eq!(ip, expected_ip);
             assert_eq!(port, expected_port);

--- a/src/worker/network.rs
+++ b/src/worker/network.rs
@@ -373,7 +373,7 @@ fn get_local_addr_port(
             carry = 0;
         }
         octets[i] = octet as u8;
-        addr_index = addr_index / 256;
+        addr_index /= 256;
     }
 
     let local_addr = IpAddress::v4(octets[0], octets[1], octets[2], octets[3]);


### PR DESCRIPTION
For the network load Berserker cycles through IP addresses and ports. Currently for every one hundred ports it increments the IP address once. This PR makes it so that the number of ports per IP address is not hard coded, but can be configured.

Also makes it so that the exact starting IP address can be set, instead of starting from x.x.0.2, and makes it so that the full range of IP addresses can be incremented through instead of just cycling through the last two octets.

### Testing

#### Summary

The image produced by this PR was used in kube-burner. Stackrox was deployed in the same cluster and the network graph was checked. Connections between pods and external IPs generated by berserker were observed.

#### Details

Starting from the root of the berserker repository

Build and push the berserker image with a client and server.
```
make
cd scripts/network
docker build .

docker image ls | head
REPOSITORY                                                                  TAG                                                  IMAGE ID       CREATED         SIZE
<none>                                                                      <none>                                               a03934ab4c9e   2 minutes ago   410MB

docker tag a03934ab4c9e quay.io/jvirtane/berserker-connection-load-1.0-77-g80d8771450-2
docker push quay.io/jvirtane/berserker-connection-load-1.0-77-g80d8771450-2
```

The image was then used in a kube-burner configuration file. Here https://github.com/stackrox/stackrox/pull/14790

A GKE cluster was created. Stackrox was deployed there. 

Starting from the root of the stacrox/actions repository.

```
cd release/start-kube-burner

export KUBECONFIG=/home/jvirtane/scripts/artifact/kubeconfig
export KUBE_BURNER_CONFIG_DIR=/home/jvirtane/go/src/github.com/stackrox/backup/stackrox/scripts/release-tools/kube-burner-configs
export BENCHMARK_OPERATOR_DIR=/home/jvirtane/software/benchmark-operator

./start-kube-burner.sh
```

The network graph UI was checked and the following was seen.

![Screenshot from 2025-04-01 13-28-55](https://github.com/user-attachments/assets/4f4546f8-d1b6-4e4c-8b98-326e7b299301)

For each deployment in the cluster-density-1 namespace about 50 connections to different external IPs was observed. This is what is expected as each pod makes 100 connections and for each IP there are two ports.