### PR TITLE
Simplify network test

### DIFF
--- a/tests/workers/network/Makefile
+++ b/tests/workers/network/Makefile
@@ -1,0 +1,5 @@
+.DEFAULT_GOAL = all
+
+.PHONY: all
+all:
+	./smoke.sh

--- a/tests/workers/network/README.md
+++ b/tests/workers/network/README.md
@@ -1,0 +1,9 @@
+A simple smoke test for network worker. The test spins two berserker instances,
+one as a server and one as a client, then uses bpftrace to confirm that accept
+syscall is getting triggered. There are few requirements to run the test:
+
+* Since the networking configuration might differ between environments, it's
+  necessary to invoke `scripts/network/prepare-tap.sh` with necessary arguments
+  before the test.
+* Test needs to be run with superuser privileges.
+* Berserker binary to test needs to be available in PATH.

--- a/tests/workers/network/smoke.sh
+++ b/tests/workers/network/smoke.sh
@@ -19,9 +19,11 @@ pkill berserker || true
 # make berserkers verbose
 #export RUST_LOG=trace
 
+TEST_DIR="$(cd -- "$( dirname -- "${BASH_SOURCE[0]}")"  &> /dev/null && pwd)"
+
 # start the server before bpftrace, to skip first accept
 echo "Starting the server..."
-berserker workload.server.toml &> /tmp/server.log &
+berserker "${TEST_DIR}/workload.server.toml" &> /tmp/server.log &
 
 # wait until it's accepting connections
 while ! echo test | socat stdio tcp4-connect:10.0.0.1:8081 ;
@@ -31,7 +33,7 @@ do
 done
 
 echo "Starting bpftrace..."
-bpftrace sys_accept.bt &> /tmp/tcpaccept.log &
+bpftrace "${TEST_DIR}/sys_accept.bt" &> /tmp/tcpaccept.log &
 
 # let bpftrace attach probes
 attempts=0
@@ -49,7 +51,7 @@ do
 done
 
 echo "Starting the client..."
-berserker workload.client.toml &> /tmp/client.log &
+berserker "${TEST_DIR}/workload.client.toml" &> /tmp/client.log &
 
 # let it do some work
 sleep 5;

--- a/tests/workers/network/smoke.sh
+++ b/tests/workers/network/smoke.sh
@@ -9,10 +9,6 @@ which berserker &>/dev/null || stop "Don't have berserker"
 which pkill &>/dev/null || stop "Don't have pkill"
 which socat &>/dev/null || stop "Don't have socat"
 
-if [ ! -d "tests/workers/network/" ]; then
-  echo "Can't find test directory. Smoke tests have to be run from the project root directory"
-fi
-
 echo "Cleanup..."
 rm -f /tmp/server.log
 rm -f /tmp/client.log
@@ -25,7 +21,7 @@ pkill berserker || true
 
 # start the server before bpftrace, to skip first accept
 echo "Starting the server..."
-berserker tests/workers/network/workload.server.toml &> /tmp/server.log &
+berserker workload.server.toml &> /tmp/server.log &
 
 # wait until it's accepting connections
 while ! echo test | socat stdio tcp4-connect:10.0.0.1:8081 ;
@@ -35,7 +31,7 @@ do
 done
 
 echo "Starting bpftrace..."
-bpftrace tests/workers/network/sys_accept.bt &> /tmp/tcpaccept.log &
+bpftrace sys_accept.bt &> /tmp/tcpaccept.log &
 
 # let bpftrace attach probes
 attempts=0
@@ -53,7 +49,7 @@ do
 done
 
 echo "Starting the client..."
-berserker tests/workers/network/workload.client.toml &> /tmp/client.log &
+berserker workload.client.toml &> /tmp/client.log &
 
 # let it do some work
 sleep 5;


### PR DESCRIPTION
Slightly simplify the test, since there is no need to run it from the root directory. Add README to describe what's going on.