### PR TITLE
Elevate clippy warnings to errors in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
         run: cargo fmt --check
 
       - name: Run clippy
-        run: cargo clippy
+        run: cargo clippy -- -D warnings
 
       - name: Run tests
         run: cargo test

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,16 +107,9 @@ fn main() {
                 let elapsed = duration_timer.elapsed().unwrap().as_secs();
 
                 if elapsed > config.duration {
-                    for handle in processes.into_iter().flatten() {
+                    for handle in processes.iter().flatten() {
                         info!("Terminating: {}", *handle);
-                        match kill(Pid::from_raw(*handle), Signal::SIGTERM) {
-                            Ok(()) => {
-                                continue;
-                            }
-                            Err(e) => {
-                                continue;
-                            }
-                        }
+                        let _ = kill(Pid::from_raw(*handle), Signal::SIGTERM);
                     }
 
                     break;
@@ -125,7 +118,7 @@ fn main() {
         }
 
         s.spawn(move || {
-            for handle in processes.into_iter().flatten() {
+            for handle in processes.iter().flatten() {
                 info!("waitpid: {}", *handle);
                 waitpid(Pid::from_raw(*handle), None).unwrap();
             }

--- a/src/worker/network.rs
+++ b/src/worker/network.rs
@@ -33,7 +33,7 @@ impl NetworkWorker {
     pub fn new(workload: WorkloadConfig, cpu: CoreId, process: usize) -> Self {
         NetworkWorker {
             config: BaseConfig { cpu, process },
-            workload: workload,
+            workload,
         }
     }
 
@@ -178,7 +178,7 @@ impl NetworkWorker {
             if elapsed > (interval * 1000.0).round() as u128 {
                 // Time for a new connection, add a socket, it state is going
                 // to be updated during the next loop round
-                total_conns = total_conns + 1;
+                total_conns += 1;
 
                 let tcp_rx_buffer = tcp::SocketBuffer::new(vec![0; 1024]);
                 let tcp_tx_buffer = tcp::SocketBuffer::new(vec![0; 1024]);
@@ -282,7 +282,7 @@ impl NetworkWorker {
                 info!("Close handle {}", h);
                 // TODO: reuse sockets
                 sockets.remove(h);
-                total_conns = total_conns - 1;
+                total_conns -= 1;
             }
 
             info!("Sockets: {}", total_conns);
@@ -296,7 +296,7 @@ impl NetworkWorker {
             let duration = iface
                 .poll_delay(timestamp, &sockets)
                 .min(Some(min_duration))
-                .or_else(|| Some(min_duration));
+                .or(Some(min_duration));
 
             info!("wait duration {:?}", duration);
             phy_wait(fd, duration).expect("wait error");
@@ -310,7 +310,7 @@ impl NetworkWorker {
         addr: Ipv4Address,
     ) -> (Interface, FaultInjector<Tracer<TunTapInterface>>, i32) {
         let device_name = "berserker0";
-        let device = TunTapInterface::new(&device_name, Medium::Ip).unwrap();
+        let device = TunTapInterface::new(device_name, Medium::Ip).unwrap();
         let fd = device.as_raw_fd();
 
         let seed = SystemTime::now()
@@ -367,7 +367,7 @@ impl NetworkWorker {
             (((index / 100) + 2) % 255) as u8,
         );
 
-        return (local_addr, local_port);
+        (local_addr, local_port)
     }
 }
 


### PR DESCRIPTION
Additionally, fix the warnings we were previously getting and ignoring.

clippy is a great tool and I think it can help us get a lot better at Rust (at least it did for me), we should not be ignoring its warnings.