### PR TITLE
Make target for network scripts dockerfile

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,12 +34,14 @@ jobs:
 
       - run: make
 
+      - run: make build-berserker-network
+
       - name: Get tag
         run: |
           TAG="$(make tag)"
-          echo "TAG=$TAG" >> $GITHUB_ENV
+          echo "TAG=$TAG" >> "$GITHUB_ENV"
 
-      - name: Retag and push rhacs-eng
+      - name: Retag and push berserker to rhacs-eng
         uses: stackrox/actions/images/retag-and-push@v1
         with:
           src-image: berserker
@@ -47,11 +49,27 @@ jobs:
           username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
           password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
 
-      - name: Retag and push stackrox-io
+      - name: Retag and push berserker to stackrox-io
         uses: stackrox/actions/images/retag-and-push@v1
         with:
           src-image: berserker
           dst-image: quay.io/stackrox-io/berserker:${{ env.TAG }}
+          username: ${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}
+          password: ${{ secrets.QUAY_STACKROX_IO_RW_PASSWORD }}
+
+      - name: Retag and push berserker-network to rhacs-eng
+        uses: stackrox/actions/images/retag-and-push@v1
+        with:
+          src-image: berserker-network
+          dst-image: quay.io/rhacs-eng/qa:berserker-network-${{ env.TAG }}
+          username: ${{ secrets.QUAY_RHACS_ENG_RW_USERNAME }}
+          password: ${{ secrets.QUAY_RHACS_ENG_RW_PASSWORD }}
+
+      - name: Retag and push berserker-network to stackrox-io
+        uses: stackrox/actions/images/retag-and-push@v1
+        with:
+          src-image: berserker-network
+          dst-image: quay.io/stackrox-io/berserker:network-${{ env.TAG }}
           username: ${{ secrets.QUAY_STACKROX_IO_RW_USERNAME }}
           password: ${{ secrets.QUAY_STACKROX_IO_RW_PASSWORD }}
 

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ all:
 	docker build -t builder -f Dockerfile.build .
 	docker build -t berserker .
 
+.PHONY: build-network
+build-berserker-network:
+	docker build -t berserker-network scripts/network
 
 .PHONY: tag
 tag:


### PR DESCRIPTION
Adds a Makefile target to build the Dockerfile added here https://github.com/stackrox/berserker/pull/32

Also makes it so that CI builds and pushes the image.