### PR TITLE
Fix prepare-tap script

### DIFF
--- a/scripts/network/prepare-tap.sh
+++ b/scripts/network/prepare-tap.sh
@@ -23,7 +23,7 @@ CONFIGURE_IPTABLE="false"
 CONFIGURE_FIREWALLD="false"
 CONFIGURE_TUNTAP_IF_EXISTS="false"
 
-while getopts ":a:t:u:i:fo" opt; do
+while getopts ":a:t:u:ifo" opt; do
   case $opt in
     a) ADDRESS="${OPTARG}"
     ;;
@@ -62,34 +62,35 @@ ip link set "${NAME}" up
 echo "Assigning address ${ADDRESS} to device ${NAME}..."
 ip addr add "${ADDRESS}" dev "${NAME}"
 
+echo "Enabling ip forward..."
+sysctl net.ipv4.ip_forward=1
+
 if [[ "${CONFIGURE_FIREWALLD}" == "true" ]];
 then
     which firewall-cmd &>/dev/null || stop "Don't have the firewal-cmd tool"
 
     echo "Adding to the trusted zone..."
-    firewall-cmd --zone=trusted --add-interface="${NAME}"
+    firewall-cmd --zone=trusted --add-interface="${NAME}" || true
 fi
 
+echo "${CONFIGURE_IPTABLE}"
 if [[ "${CONFIGURE_IPTABLE}" == "true" ]];
 then
-    which iptables &>/dev/null || stop "Don't have the iptables tool"
-
-    echo "Enabling ip forward..."
-    sysctl net.ipv4.ip_forward=1
+    which iptables-nft &>/dev/null || stop "Don't have the iptables tool"
 
     echo "Preparing iptable..."
-    iptables -t nat -A POSTROUTING -s "${ADDRESS}" -j MASQUERADE
-    iptables -A FORWARD -i "${NAME}" -s "${ADDRESS}" -j ACCEPT
-    iptables -A FORWARD -o "${NAME}" -d "${ADDRESS}" -j ACCEPT
+    iptables-nft -t nat -A POSTROUTING -s "${ADDRESS}" -j MASQUERADE
+    iptables-nft -A FORWARD -i "${NAME}" -s "${ADDRESS}" -j ACCEPT
+    iptables-nft -A FORWARD -o "${NAME}" -d "${ADDRESS}" -j ACCEPT
 
-    RULE_NR=$(iptables -t filter -L INPUT --line-numbers |\
+    RULE_NR=$(iptables-nft -t filter -L INPUT --line-numbers |\
                 grep "REJECT     all" |\
                 awk '{print $1}')
 
     # Excempt tun device from potentiall reject all rule
     if [[ $RULE_NR == "" ]]; then
-        iptables -I INPUT -i "${NAME}" -s "${ADDRESS}" -j ACCEPT
+        iptables-nft -I INPUT -i "${NAME}" -s "${ADDRESS}" -j ACCEPT
     else
-        iptables -I INPUT $((RULE_NR - 1)) -i "${NAME}" -s "${ADDRESS}" -j ACCEPT
+        iptables-nft -I INPUT $((RULE_NR - 1)) -i "${NAME}" -s "${ADDRESS}" -j ACCEPT
     fi
 fi


### PR DESCRIPTION
Fedora 42 now features new iptables, reflect this in the script. Also fix few minor issues: move out sysctl bit to make it independent, and correct getopts syntax to not require a value for -i/-f/-o.