### PR TITLE
Fix config for network smoke test

### DIFF
--- a/tests/workers/network/workload.client.toml
+++ b/tests/workers/network/workload.client.toml
@@ -9,4 +9,6 @@ address = "10.0.0.1"
 target_port = 8081
 arrival_rate = 100
 departure_rate = 1
-nconnections = 10
+connections_static = 1
+connections_dyn_max = 100
+preempt = false

--- a/tests/workers/network/workload.server.toml
+++ b/tests/workers/network/workload.server.toml
@@ -9,4 +9,6 @@ address = "10.0.0.1"
 target_port = 8081
 arrival_rate = 0.1
 departure_rate = 0.1
-nconnections = 10
+connections_static = 10
+connections_dyn_max = 100
+preempt = true


### PR DESCRIPTION
Recent changes in network worker were not reflected in the smoke test, correct that.