### PR TITLE
Fix connection load

### DIFF
--- a/scripts/network/init.sh
+++ b/scripts/network/init.sh
@@ -10,6 +10,8 @@ berserker -c /etc/berserker/network-server.toml &
 
 SERVER_PID=$!
 
+sleep 1
+
 berserker -c /etc/berserker/network-client.toml &
 
 CLIENT_PID=$!
@@ -17,12 +19,12 @@ CLIENT_PID=$!
 cleanup() {
     echo "Killing client ($CLIENT_PID) and server ($SERVER_PID)"
 
-    kill -9 "$CLIENT_PID"
-    kill -9 "$SERVER_PID"
+    kill -9 "$CLIENT_PID" 2>/dev/null
+    kill -9 "$SERVER_PID" 2>/dev/null
 
     exit
 }
 
-trap cleanup SIGINT SIGABRT
+trap cleanup SIGINT SIGABRT SIGTERM
 
-wait -n "$SERVER_PID" "$CLIENT_PID"
+wait "$SERVER_PID" "$CLIENT_PID"

--- a/src/worker/network.rs
+++ b/src/worker/network.rs
@@ -52,7 +52,7 @@ impl NetworkWorker {
         let listener = loop {
             match TcpListener::bind((addr.to_string(), target_port)) {
                 Ok(l) => break l,
-                Err(e) if e.kind() == std::io::ErrorKind::AddrInUse => {
+                Err(e) if e.kind() == io::ErrorKind::AddrInUse => {
                     retries += 1;
                     if retries > MAX_BIND_RETRIES {
                         return Err(WorkerError::InternalWithMessage(format!(
@@ -60,7 +60,7 @@ impl NetworkWorker {
                             addr, target_port, MAX_BIND_RETRIES, e
                         )));
                     }
-                    thread::sleep(std::time::Duration::from_secs(1));
+                    thread::sleep(Duration::from_secs(1));
                 }
                 Err(e) => panic!("Failed to bind: {}", e),
             }

--- a/src/worker/network.rs
+++ b/src/worker/network.rs
@@ -55,12 +55,10 @@ impl NetworkWorker {
                 Err(e) if e.kind() == std::io::ErrorKind::AddrInUse => {
                     retries += 1;
                     if retries > MAX_BIND_RETRIES {
-                        return Err(WorkerError::InternalWithMessage(
-                            format!(
-                                "Failed to bind {}:{} after {} retries: {}",
-                                addr, target_port, MAX_BIND_RETRIES, e
-                            ),
-                        ));
+                        return Err(WorkerError::InternalWithMessage(format!(
+                            "Failed to bind {}:{} after {} retries: {}",
+                            addr, target_port, MAX_BIND_RETRIES, e
+                        )));
                     }
                     thread::sleep(std::time::Duration::from_secs(1));
                 }

--- a/src/worker/network.rs
+++ b/src/worker/network.rs
@@ -47,14 +47,21 @@ impl NetworkWorker {
     ) -> Result<(), WorkerError> {
         debug!("Starting server at {:?}:{:?}", addr, target_port);
 
+        const MAX_BIND_RETRIES: u32 = 30;
+        let mut retries = 0;
         let listener = loop {
             match TcpListener::bind((addr.to_string(), target_port)) {
                 Ok(l) => break l,
                 Err(e) if e.kind() == std::io::ErrorKind::AddrInUse => {
-                    info!(
-                        "Address {}:{} in use, retrying in 1s",
-                        addr, target_port
-                    );
+                    retries += 1;
+                    if retries > MAX_BIND_RETRIES {
+                        return Err(WorkerError::InternalWithMessage(
+                            format!(
+                                "Failed to bind {}:{} after {} retries: {}",
+                                addr, target_port, MAX_BIND_RETRIES, e
+                            ),
+                        ));
+                    }
                     thread::sleep(std::time::Duration::from_secs(1));
                 }
                 Err(e) => panic!("Failed to bind: {}", e),

--- a/src/worker/network.rs
+++ b/src/worker/network.rs
@@ -47,8 +47,19 @@ impl NetworkWorker {
     ) -> Result<(), WorkerError> {
         debug!("Starting server at {:?}:{:?}", addr, target_port);
 
-        let listener =
-            TcpListener::bind((addr.to_string(), target_port)).unwrap();
+        let listener = loop {
+            match TcpListener::bind((addr.to_string(), target_port)) {
+                Ok(l) => break l,
+                Err(e) if e.kind() == std::io::ErrorKind::AddrInUse => {
+                    info!(
+                        "Address {}:{} in use, retrying in 1s",
+                        addr, target_port
+                    );
+                    thread::sleep(std::time::Duration::from_secs(1));
+                }
+                Err(e) => panic!("Failed to bind: {}", e),
+            }
+        };
 
         for stream in listener.incoming() {
             let mut stream = stream.unwrap();

--- a/src/worker/network.rs
+++ b/src/worker/network.rs
@@ -39,6 +39,29 @@ impl NetworkWorker {
         }
     }
 
+    fn bind_port(
+        &self,
+        addr: Ipv4Address,
+        target_port: u16,
+    ) -> Result<TcpListener, WorkerError> {
+        const MAX_BIND_RETRIES: usize = 30;
+        let addr = addr.to_string();
+        for _ in 0..MAX_BIND_RETRIES {
+            match TcpListener::bind((addr.as_str(), target_port)) {
+                Ok(l) => return Ok(l),
+                Err(e) if e.kind() == io::ErrorKind::AddrInUse => {
+                    thread::sleep(Duration::from_secs(1));
+                }
+                Err(e) => panic!("Failed to bind: {}", e),
+            }
+        }
+
+        Err(WorkerError::InternalWithMessage(format!(
+            "Failed to bind {}:{} after {} retries: address in use",
+            addr, target_port, MAX_BIND_RETRIES
+        )))
+    }
+
     /// Start a simple server. The client side is going to be a networking
     /// worker as well, so for convenience of troubleshooting do not error
     /// out if something unexpected happened, log and proceed instead.
@@ -49,24 +72,7 @@ impl NetworkWorker {
     ) -> Result<(), WorkerError> {
         debug!("Starting server at {:?}:{:?}", addr, target_port);
 
-        const MAX_BIND_RETRIES: u32 = 30;
-        let mut retries = 0;
-        let listener = loop {
-            match TcpListener::bind((addr.to_string(), target_port)) {
-                Ok(l) => break l,
-                Err(e) if e.kind() == io::ErrorKind::AddrInUse => {
-                    retries += 1;
-                    if retries > MAX_BIND_RETRIES {
-                        return Err(WorkerError::InternalWithMessage(format!(
-                            "Failed to bind {}:{} after {} retries: {}",
-                            addr, target_port, MAX_BIND_RETRIES, e
-                        )));
-                    }
-                    thread::sleep(Duration::from_secs(1));
-                }
-                Err(e) => panic!("Failed to bind: {}", e),
-            }
-        };
+        let listener = self.bind_port(addr, target_port)?;
 
         for stream in listener.incoming() {
             let mut stream = stream.unwrap();

--- a/src/worker/network.rs
+++ b/src/worker/network.rs
@@ -8,9 +8,11 @@ use std::str;
 use std::time::{SystemTime, UNIX_EPOCH};
 use std::{
     fmt::Display,
+    io,
     io::{BufReader, prelude::*},
     net::TcpListener,
     thread,
+    time::Duration,
 };
 
 use crate::{BaseConfig, Worker, WorkerError, Workload, WorkloadConfig};


### PR DESCRIPTION
Previously the connection load pods would sometimes crash. There are two fixes here. The first is a sleep between starting the server and client in the `init.sh` script, to reduce the chances of a race condition leading to a crash. The second is that if connection load attempts to use a port already in use it sleeps for 1 second before retrying, instead of immediately crashing. It retries up to 30 times. This will be especially useful when berserker has multiple workers at the same time opening and closing ports.